### PR TITLE
Add orders functionality with permissions and database tables

### DIFF
--- a/Constants/Permissions.cs
+++ b/Constants/Permissions.cs
@@ -43,6 +43,14 @@ public static class Permissions
         public const string Edit = "Permissions.ProductCategories.Edit";
         public const string Delete = "Permissions.ProductCategories.Delete";
     }
+    
+    public static class Orders
+    {
+        public const string View = "Permissions.Orders.View";
+        public const string Create = "Permissions.Orders.Create";
+        public const string Edit = "Permissions.Orders.Edit";
+        public const string Delete = "Permissions.Orders.Delete";
+    }
 
     // Helper method to get all permissions
     public static IEnumerable<string> GetAllPermissions()

--- a/Controllers/OrdersController.cs
+++ b/Controllers/OrdersController.cs
@@ -1,0 +1,215 @@
+﻿using System.Security.Claims;
+using AdminHubApi.Constants;
+using AdminHubApi.Dtos.Orders;
+using AdminHubApi.Entities;
+using AdminHubApi.Interfaces;
+using AdminHubApi.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AdminHubApi.Controllers;
+
+[ApiController]
+[Route("/api/orders")]
+[PermissionAuthorize(Permissions.Orders.View)]
+public class OrdersController : ControllerBase
+{
+    private readonly IOrderService _orderService;
+    private readonly ILogger<OrdersController> _logger;
+
+    public OrdersController(IOrderService orderService, ILogger<OrdersController> logger)
+    {
+        _orderService = orderService;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<OrderResponseDto>>> GetAllOrders()
+    {
+        var response = await _orderService.GetAllAsync();
+
+        if (!response.Succeeded)
+        {
+            return BadRequest(response);
+        }
+
+        return Ok(response.Data);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<OrderResponseDto>> GetOrderById(Guid id)
+    {
+        var response = await _orderService.GetByIdAsync(id);
+
+        if (!response.Succeeded)
+        {
+            return NotFound(response);
+        }
+
+        return Ok(response.Data);
+    }
+
+    [HttpPost]
+    [PermissionAuthorize(Permissions.Orders.Create)]
+    public async Task<ActionResult<OrderResponseDto>> CreateOrder(CreateOrderDto createOrderDto)
+    {
+        var order = new Order
+        {
+            Id = Guid.NewGuid(),
+
+            // Include both registered user id and order-specific customer info
+            CustomerId = createOrderDto.CustomerId,
+            CustomerName = createOrderDto.CustomerName,
+            CustomerEmail = createOrderDto.CustomerEmail,
+            CustomerPhone = createOrderDto.CustomerPhone,
+
+            Status = createOrderDto.Status,
+            ShippingAddress = createOrderDto.ShippingAddress,
+            BillingAddress = createOrderDto.BillingAddress,
+            PaymentMethod = createOrderDto.PaymentMethod,
+            Created = DateTime.UtcNow,
+            CreatedById = createOrderDto.CreatedById,
+            Modified = DateTime.UtcNow,
+            ModifiedById = createOrderDto.CreatedById
+        };
+
+        var orderItems = createOrderDto.OrderItems.Select(item => new OrderItem
+        {
+            Id = Guid.NewGuid(),
+            ProductId = item.ProductId,
+            Quantity = item.Quantity
+        }).ToList();
+
+        var response = await _orderService.CreateAsync(order, orderItems);
+
+        if (!response.Succeeded)
+        {
+            return BadRequest(response);
+        }
+
+        return CreatedAtAction(nameof(GetOrderById), new { id = order.Id }, response.Data);
+    }
+
+    [HttpPut("{id}")]
+    [PermissionAuthorize(Permissions.Orders.Edit)]
+    public async Task<IActionResult> UpdateOrder(Guid id, UpdateOrderDto updateOrderDto)
+    {
+        var orderResponse = await _orderService.GetByIdAsync(id);
+
+        if (!orderResponse.Succeeded)
+        {
+            return NotFound(orderResponse);
+        }
+
+        var order = await _orderService.GetByIdAsync(id);
+
+        if (!order.Succeeded)
+        {
+            return NotFound(order);
+        }
+
+        var existingOrder = await _orderService.GetByIdAsync(id);
+
+        if (!existingOrder.Succeeded)
+        {
+            return NotFound(existingOrder);
+        }
+
+        var orderEntity = new Order
+        {
+            Id = id,
+            
+            // Update customer information
+            CustomerName = updateOrderDto.CustomerName,
+            CustomerEmail = updateOrderDto.CustomerEmail,
+            CustomerPhone = updateOrderDto.CustomerPhone,
+            
+            OrderDate = existingOrder.Data.OrderDate,
+            TotalAmount = existingOrder.Data.TotalAmount,
+            Status = updateOrderDto.Status,
+            ShippingAddress = updateOrderDto.ShippingAddress ?? existingOrder.Data.ShippingAddress,
+            BillingAddress = updateOrderDto.BillingAddress ?? existingOrder.Data.BillingAddress,
+            PaymentMethod = updateOrderDto.PaymentMethod ?? existingOrder.Data.PaymentMethod,
+            Created = existingOrder.Data.Created,
+            CreatedById = existingOrder.Data.CreatedById,
+            Modified = DateTime.UtcNow,
+            ModifiedById = updateOrderDto.ModifiedById
+        };
+
+        var updateResponse = await _orderService.UpdateAsync(orderEntity);
+
+        if (!updateResponse.Succeeded)
+        {
+            return BadRequest(updateResponse);
+        }
+
+        return Ok(updateResponse.Data);
+    }
+
+    [HttpDelete("{id}")]
+    [PermissionAuthorize(Permissions.Orders.Delete)]
+    public async Task<IActionResult> DeleteOrder(Guid id)
+    {
+        var order = await _orderService.GetByIdAsync(id);
+
+        if (!order.Succeeded)
+        {
+            return NotFound(order);
+        }
+
+        var deleteResponse = await _orderService.DeleteAsync(id);
+
+        if (!deleteResponse.Succeeded)
+        {
+            return BadRequest(deleteResponse);
+        }
+
+        return NoContent();
+    }
+
+    [HttpGet("customer/{customerId}")]
+    public async Task<ActionResult<IEnumerable<OrderResponseDto>>> GetOrdersByCustomer(string customerId)
+    {
+        var response = await _orderService.GetByCustomerIdAsync(customerId);
+
+        if (!response.Succeeded)
+        {
+            return BadRequest(response);
+        }
+
+        return Ok(response.Data);
+    }
+
+    [HttpGet("status/{status}")]
+    public async Task<ActionResult<IEnumerable<OrderResponseDto>>> GetOrdersByStatus(OrderStatus status)
+    {
+        var response = await _orderService.GetByStatusAsync(status);
+
+        if (!response.Succeeded)
+        {
+            return BadRequest(response);
+        }
+
+        return Ok(response.Data);
+    }
+    
+    [HttpGet("customer-info")]
+    public async Task<ActionResult<CustomerInfo>> GetCustomerInfo()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+    
+        if (string.IsNullOrEmpty(userId))
+        {
+            return BadRequest("User ID not found");
+        }
+    
+        var response = await _orderService.GetCustomerInfoAsync(userId);
+    
+        if (!response.Succeeded)
+        {
+            return BadRequest(response);
+        }
+    
+        return Ok(response.Data);
+    }
+}

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -10,11 +10,11 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     { }
     
     public DbSet<Project> Projects { get; set; }
-    
     public DbSet<BlacklistedToken> BlacklistedTokens { get; set; }
-    
     public DbSet<Product> Products { get; set; }
     public DbSet<ProductCategory> ProductCategories { get; set; }
+    public DbSet<Order> Orders { get; set; }
+    public DbSet<OrderItem> OrderItems { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/Data/Seeders/AdminUserSeeder.cs
+++ b/Data/Seeders/AdminUserSeeder.cs
@@ -15,7 +15,7 @@ namespace AdminHubApi.Data.Seeders
             var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
 
             // Get admin user details from configuration
-            var adminEmail = configuration["AdminUser:Email"] ?? "admin@example.com";
+            var adminEmail = configuration["AdminUser:Email"] ?? "admin@adminhub.com";
             var adminUserName = configuration["AdminUser:UserName"] ?? "admin";
             var adminPassword = configuration["AdminUser:Password"] ?? "Admin@Password123!"; // Should be in secrets in production
 
@@ -40,7 +40,7 @@ namespace AdminHubApi.Data.Seeders
                 {
                     logger.LogInformation($"Admin user created successfully");
                     
-                    // Add to Admin role
+                    // Add to the Admin role
                     await userManager.AddToRoleAsync(adminUser, RoleSeeder.AdminRole);
                     
                     // Add all admin permissions
@@ -50,10 +50,31 @@ namespace AdminHubApi.Data.Seeders
                         new Claim(CustomClaimTypes.Permission, Permissions.Users.Create),
                         new Claim(CustomClaimTypes.Permission, Permissions.Users.Edit),
                         new Claim(CustomClaimTypes.Permission, Permissions.Users.Delete),
+                        
                         new Claim(CustomClaimTypes.Permission, Permissions.Roles.View),
                         new Claim(CustomClaimTypes.Permission, Permissions.Roles.Create),
                         new Claim(CustomClaimTypes.Permission, Permissions.Roles.Edit),
                         new Claim(CustomClaimTypes.Permission, Permissions.Roles.Delete),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.Projects.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Projects.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Projects.Edit),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Projects.Delete),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.Edit),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.Delete),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Edit),
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Delete),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.Edit),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.Delete),
                     };
                     
                     await userManager.AddClaimsAsync(adminUser, adminPermissions);

--- a/Data/Seeders/ManagerUserSeeder.cs
+++ b/Data/Seeders/ManagerUserSeeder.cs
@@ -15,7 +15,7 @@ namespace AdminHubApi.Data.Seeders
             var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
 
             // Get manager user details from configuration
-            var managerEmail = configuration["ManagerUser:Email"] ?? "manager@example.com";
+            var managerEmail = configuration["ManagerUser:Email"] ?? "manager@adminhub.com";
             var managerUserName = configuration["ManagerUser:UserName"] ?? "manager_user";
             var managerPassword = configuration["ManagerUser:Password"] ?? "Manager@Pass1";
 
@@ -49,11 +49,25 @@ namespace AdminHubApi.Data.Seeders
                         new Claim(CustomClaimTypes.Permission, Permissions.Users.View),
                         new Claim(CustomClaimTypes.Permission, Permissions.Users.Create),
                         new Claim(CustomClaimTypes.Permission, Permissions.Users.Edit),
+                        
                         new Claim(CustomClaimTypes.Permission, Permissions.Roles.View),
+                        
                         new Claim(CustomClaimTypes.Permission, Permissions.Projects.View),
                         new Claim(CustomClaimTypes.Permission, Permissions.Projects.Create),
                         new Claim(CustomClaimTypes.Permission, Permissions.Projects.Edit),
                         new Claim(CustomClaimTypes.Permission, Permissions.Projects.Delete),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.Edit),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Edit),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.Edit),
                     };
 
                     await userManager.AddClaimsAsync(managerUser, userPermissions);
@@ -68,10 +82,10 @@ namespace AdminHubApi.Data.Seeders
             {
                 logger.LogInformation("Manager user already exists");
 
-                // Ensure manager is in the manager role
-                if (!await userManager.IsInRoleAsync(managerUser, RoleSeeder.UserRole))
+                // Ensure a manager is in the manager role
+                if (!await userManager.IsInRoleAsync(managerUser, RoleSeeder.ManagerRole))
                 {
-                    await userManager.AddToRoleAsync(managerUser, RoleSeeder.UserRole);
+                    await userManager.AddToRoleAsync(managerUser, RoleSeeder.ManagerRole);
                     logger.LogInformation("Added existing manager user to manager role");
                 }
             }

--- a/Data/Seeders/NormalUserSeeder.cs
+++ b/Data/Seeders/NormalUserSeeder.cs
@@ -15,7 +15,7 @@ namespace AdminHubApi.Data.Seeders
             var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
 
             // Get admin user details from configuration
-            var demoEmail = configuration["DemoUser:Email"] ?? "demo@example.com";
+            var demoEmail = configuration["DemoUser:Email"] ?? "demo@adminhub.com";
             var demoUserName = configuration["DemoUser:UserName"] ?? "demo_user"; 
             var demoPassword = configuration["DemoUser:Password"] ?? "Demo@Pass1";
 
@@ -48,7 +48,22 @@ namespace AdminHubApi.Data.Seeders
                     {
                         new Claim(CustomClaimTypes.Permission, Permissions.Users.View),
                         new Claim(CustomClaimTypes.Permission, Permissions.Users.Edit),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.Roles.View),
+                        
                         new Claim(CustomClaimTypes.Permission, Permissions.Projects.View),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Products.Edit),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Edit),
+                        
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.View),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.Create),
+                        new Claim(CustomClaimTypes.Permission, Permissions.Orders.Edit),
                     };
 
                     await userManager.AddClaimsAsync(demoUser, userPermissions);

--- a/Data/Seeders/PermissionUpdateSeeder.cs
+++ b/Data/Seeders/PermissionUpdateSeeder.cs
@@ -18,28 +18,85 @@ namespace AdminHubApi.Data.Seeders
             var projectPermissions = new Dictionary<string, string[]>
             {
                 {
-                    RoleSeeder.AdminRole, new[]
-                    {
+                    RoleSeeder.AdminRole, [
+                        Permissions.Users.View,
+                        Permissions.Users.Create,
+                        Permissions.Users.Edit,
+                        Permissions.Users.Delete,
+
+                        Permissions.Roles.View,
+                        Permissions.Roles.Create,
+                        Permissions.Roles.Edit,
+                        Permissions.Roles.Delete,
+
                         Permissions.Projects.View,
                         Permissions.Projects.Create,
                         Permissions.Projects.Edit,
-                        Permissions.Projects.Delete
-                    }
+                        Permissions.Projects.Delete,
+
+                        Permissions.Products.View,
+                        Permissions.Products.Create,
+                        Permissions.Products.Edit,
+                        Permissions.Products.Delete,
+
+                        Permissions.ProductCategories.View,
+                        Permissions.ProductCategories.Create,
+                        Permissions.ProductCategories.Edit,
+                        Permissions.ProductCategories.Delete,
+
+                        Permissions.Orders.View,
+                        Permissions.Orders.Create,
+                        Permissions.Orders.Edit,
+                        Permissions.Orders.Delete,
+                    ]
                 },
                 {
-                    RoleSeeder.ManagerRole, new[]
-                    {
+                    RoleSeeder.ManagerRole, [
+                        Permissions.Users.View,
+                        Permissions.Users.Create,
+                        Permissions.Users.Edit,
+
+                        Permissions.Roles.View,
+
                         Permissions.Projects.View,
                         Permissions.Projects.Create,
                         Permissions.Projects.Edit,
-                        Permissions.Projects.Delete
-                    }
+                        Permissions.Projects.Delete,
+
+                        Permissions.Products.View,
+                        Permissions.Products.Create,
+                        Permissions.Products.Edit,
+
+                        Permissions.ProductCategories.View,
+                        Permissions.ProductCategories.Create,
+                        Permissions.ProductCategories.Edit,
+
+                        Permissions.Orders.View,
+                        Permissions.Orders.Create,
+                        Permissions.Orders.Edit,
+                    ]
                 },
                 {
-                    RoleSeeder.UserRole, new[]
-                    {
-                        Permissions.Projects.View
-                    }
+                    RoleSeeder.UserRole, [
+                        Permissions.Users.View,
+                        Permissions.Users.Edit,
+
+                        Permissions.Roles.View,
+
+                        Permissions.Projects.View,
+
+                        Permissions.Products.View,
+                        Permissions.Products.Create,
+                        Permissions.Products.Edit,
+
+                        Permissions.ProductCategories.View,
+                        Permissions.ProductCategories.Create,
+                        Permissions.ProductCategories.Edit,
+
+                        Permissions.Orders.View,
+                        Permissions.Orders.Create,
+                        Permissions.Orders.Edit,
+                    ]
                 }
             };
 

--- a/Data/Seeders/RoleSeeder.cs
+++ b/Data/Seeders/RoleSeeder.cs
@@ -28,22 +28,31 @@ namespace AdminHubApi.Data.Seeders
                     Permissions.Users.Create,
                     Permissions.Users.Edit,
                     Permissions.Users.Delete,
+                    
                     Permissions.Roles.View,
                     Permissions.Roles.Create,
                     Permissions.Roles.Edit,
                     Permissions.Roles.Delete,
+                    
                     Permissions.Projects.View,
                     Permissions.Projects.Create,
                     Permissions.Projects.Edit,
                     Permissions.Projects.Delete,
+                    
                     Permissions.Products.View,
                     Permissions.Products.Create,
                     Permissions.Products.Edit,
                     Permissions.Products.Delete,
+                    
                     Permissions.ProductCategories.View,
                     Permissions.ProductCategories.Create,
                     Permissions.ProductCategories.Edit,
-                    Permissions.ProductCategories.Delete
+                    Permissions.ProductCategories.Delete,
+                    
+                    Permissions.Orders.View,
+                    Permissions.Orders.Create,
+                    Permissions.Orders.Edit,
+                    Permissions.Orders.Delete,
                 ]
             },
             {
@@ -51,34 +60,47 @@ namespace AdminHubApi.Data.Seeders
                     Permissions.Users.View,
                     Permissions.Users.Create,
                     Permissions.Users.Edit,
+                    
                     Permissions.Roles.View,
+                    
                     Permissions.Projects.View,
                     Permissions.Projects.Create,
                     Permissions.Projects.Edit,
                     Permissions.Projects.Delete,
+                    
                     Permissions.Products.View,
                     Permissions.Products.Create,
                     Permissions.Products.Edit,
-                    Permissions.Products.Delete,
+                    
                     Permissions.ProductCategories.View,
                     Permissions.ProductCategories.Create,
                     Permissions.ProductCategories.Edit,
-                    Permissions.ProductCategories.Delete
+                    
+                    Permissions.Orders.View,
+                    Permissions.Orders.Create,
+                    Permissions.Orders.Edit,
                 ]
             },
             {
                 UserRole, [
                     Permissions.Users.View,
                     Permissions.Users.Edit,
+                    
+                    Permissions.Roles.View,
+                    
                     Permissions.Projects.View,
+                    
                     Permissions.Products.View,
                     Permissions.Products.Create,
                     Permissions.Products.Edit,
-                    Permissions.Products.Delete,
+                    
                     Permissions.ProductCategories.View,
                     Permissions.ProductCategories.Create,
                     Permissions.ProductCategories.Edit,
-                    Permissions.ProductCategories.Delete
+                    
+                    Permissions.Orders.View,
+                    Permissions.Orders.Create,
+                    Permissions.Orders.Edit,
                 ]
             }
         };

--- a/Data/Seeders/UserPermissionUpdateSeeder.cs
+++ b/Data/Seeders/UserPermissionUpdateSeeder.cs
@@ -1,0 +1,147 @@
+﻿using System.Security.Claims;
+using AdminHubApi.Constants;
+using AdminHubApi.Entities;
+using Microsoft.AspNetCore.Identity;
+
+namespace AdminHubApi.Data.Seeders
+{
+    public static class UserPermissionUpdateSeeder
+    {
+        public static async Task UpdateUserPermissionsAsync(IServiceProvider serviceProvider)
+        {
+            using var scope = serviceProvider.CreateScope();
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<ApplicationUser>>();
+
+            logger.LogInformation("Starting user permissions update process...");
+
+            // Update admin permissions
+            var adminUser = await userManager.FindByEmailAsync("admin@adminhub.com");
+            if (adminUser != null)
+            {
+                var adminPermissions = new List<Claim>
+                {
+                    // List all the expected permissions for admin users
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.Edit),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.Delete),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Roles.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Roles.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Roles.Edit),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Roles.Delete),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.Edit),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.Delete),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.Edit),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.Delete),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Edit),
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Delete),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.Edit),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.Delete),
+                };
+                
+                await UpdateUserClaimsAsync(userManager, adminUser, adminPermissions, logger);
+            }
+
+            // Update manager permissions
+            var managerUser = await userManager.FindByEmailAsync("manager@adminhub.com");
+            if (managerUser != null)
+            {
+                var managerPermissions = new List<Claim>
+                {
+                    // List all the expected permissions for manager users
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.Edit),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Roles.View),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.Edit),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.Delete),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.Edit),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Edit),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.Edit),
+                };
+                
+                await UpdateUserClaimsAsync(userManager, managerUser, managerPermissions, logger);
+            }
+
+            // Update normal user permissions
+            var normalUser = await userManager.FindByEmailAsync("demo@adminhub.com");
+            if (normalUser != null)
+            {
+                var normalUserPermissions = new List<Claim>
+                {
+                    // List all the expected permissions for normal users
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Users.Edit),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Roles.View),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Projects.Edit),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Products.Edit),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.ProductCategories.Edit),
+                    
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.View),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.Create),
+                    new Claim(CustomClaimTypes.Permission, Permissions.Orders.Edit),
+                };
+                
+                await UpdateUserClaimsAsync(userManager, normalUser, normalUserPermissions, logger);
+            }
+
+            logger.LogInformation("User permissions update completed successfully");
+        }
+
+        private static async Task UpdateUserClaimsAsync(
+            UserManager<ApplicationUser> userManager,
+            ApplicationUser user,
+            List<Claim> expectedClaims,
+            ILogger logger)
+        {
+            var currentClaims = await userManager.GetClaimsAsync(user);
+            
+            // Find claims to add (those that exist in expected but not in current)
+            foreach (var claim in expectedClaims)
+            {
+                if (!currentClaims.Any(c => c.Type == claim.Type && c.Value == claim.Value))
+                {
+                    logger.LogInformation($"Adding permission '{claim.Value}' to user '{user.UserName}'");
+                    await userManager.AddClaimAsync(user, claim);
+                }
+            }
+        }
+    }
+}

--- a/Dtos/OrderItem/CreateOrderItemDto.cs
+++ b/Dtos/OrderItem/CreateOrderItemDto.cs
@@ -1,0 +1,7 @@
+﻿namespace AdminHubApi.Dtos.OrderItem;
+
+public class CreateOrderItemDto
+{
+    public Guid ProductId { get; set; }
+    public int Quantity { get; set; }
+}

--- a/Dtos/OrderItem/OrderDto.cs
+++ b/Dtos/OrderItem/OrderDto.cs
@@ -1,0 +1,15 @@
+﻿namespace AdminHubApi.Dtos.OrderItem;
+
+public class OrderItemDto
+{
+    public Guid Id { get; set; }
+    public Guid OrderId { get; set; }
+    public Guid ProductId { get; set; }
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+    public decimal Subtotal { get; set; }
+    public DateTime Created { get; set; }
+    public string? CreatedById { get; set; }
+    public DateTime Modified { get; set; }
+    public string? ModifiedById { get; set; }
+}

--- a/Dtos/OrderItem/OrderItemResponseDto.cs
+++ b/Dtos/OrderItem/OrderItemResponseDto.cs
@@ -1,0 +1,14 @@
+﻿namespace AdminHubApi.Dtos.OrderItem;
+
+public class OrderItemResponseDto
+{
+    public Guid Id { get; set; }
+    public Guid OrderId { get; set; }
+    public Guid ProductId { get; set; }
+    public string ProductName { get; set; }
+    public int Quantity { get; set; }
+    public decimal UnitPrice { get; set; }
+    public decimal Subtotal { get; set; }
+    public DateTime Created { get; set; }
+    public DateTime Modified { get; set; }
+}

--- a/Dtos/Orders/CreateOrderDto.cs
+++ b/Dtos/Orders/CreateOrderDto.cs
@@ -1,0 +1,18 @@
+﻿using AdminHubApi.Dtos.OrderItem;
+using AdminHubApi.Entities;
+
+namespace AdminHubApi.Dtos.Orders;
+
+public class CreateOrderDto
+{
+    public string CustomerId { get; set; }
+    public string CustomerName { get; set; }
+    public string CustomerEmail { get; set; }
+    public string CustomerPhone { get; set; }
+    public string ShippingAddress { get; set; }
+    public string BillingAddress { get; set; }
+    public string PaymentMethod { get; set; }
+    public OrderStatus Status { get; set; }
+    public ICollection<CreateOrderItemDto> OrderItems { get; set; } = new List<CreateOrderItemDto>();
+    public string CreatedById { get; set; }
+}

--- a/Dtos/Orders/CustomerInfo.cs
+++ b/Dtos/Orders/CustomerInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace AdminHubApi.Dtos.Orders;
+
+public class CustomerInfo
+{
+    public string Name { get; set; }
+    public string Email { get; set; }
+    public string Phone { get; set; }
+}

--- a/Dtos/Orders/OrderDto.cs
+++ b/Dtos/Orders/OrderDto.cs
@@ -1,0 +1,28 @@
+﻿using AdminHubApi.Dtos.OrderItem;
+using AdminHubApi.Entities;
+
+namespace AdminHubApi.Dtos.Orders;
+
+public class OrderDto
+{
+    public Guid Id { get; set; }
+    // Optional link to registered user
+    public string? CustomerId { get; set; }
+    
+    // Order-specific customer information
+    public string CustomerName { get; set; }
+    public string CustomerEmail { get; set; }
+    public string CustomerPhone { get; set; }
+
+    public DateTime OrderDate { get; set; }
+    public decimal TotalAmount { get; set; }
+    public OrderStatus Status { get; set; }
+    public string ShippingAddress { get; set; }
+    public string BillingAddress { get; set; }
+    public string PaymentMethod { get; set; }
+    public ICollection<OrderItemDto> OrderItems { get; set; } = new List<OrderItemDto>();
+    public DateTime Created { get; set; }
+    public string CreatedById { get; set; }
+    public DateTime Modified { get; set; }
+    public string ModifiedById { get; set; }
+}

--- a/Dtos/Orders/OrderResponseDto.cs
+++ b/Dtos/Orders/OrderResponseDto.cs
@@ -1,0 +1,26 @@
+﻿using AdminHubApi.Dtos.OrderItem;
+using AdminHubApi.Entities;
+
+namespace AdminHubApi.Dtos.Orders;
+
+public class OrderResponseDto
+{
+    public Guid Id { get; set; }
+    public string CustomerId { get; set; }
+    public string CustomerName { get; set; }
+    public string CustomerEmail { get; set; }
+    public string CustomerPhone { get; set; }
+    public DateTime OrderDate { get; set; }
+    public decimal TotalAmount { get; set; }
+    public OrderStatus Status { get; set; }
+    public string ShippingAddress { get; set; }
+    public string BillingAddress { get; set; }
+    public string PaymentMethod { get; set; }
+    public ICollection<OrderItemResponseDto> OrderItems { get; set; } = new List<OrderItemResponseDto>();
+    public DateTime Created { get; set; }
+    public string CreatedById { get; set; }
+    public string CreatedByName { get; set; }
+    public DateTime Modified { get; set; }
+    public string ModifiedById { get; set; }
+    public string ModifiedByName { get; set; }
+}

--- a/Dtos/Orders/UpdateOrderDto.cs
+++ b/Dtos/Orders/UpdateOrderDto.cs
@@ -1,0 +1,15 @@
+﻿using AdminHubApi.Entities;
+
+namespace AdminHubApi.Dtos.Orders;
+
+public class UpdateOrderDto
+{
+    public string CustomerName { get; set; }
+    public string CustomerEmail { get; set; }
+    public string CustomerPhone { get; set; }
+    public OrderStatus Status { get; set; }
+    public string ShippingAddress { get; set; }
+    public string BillingAddress { get; set; }
+    public string PaymentMethod { get; set; }
+    public string ModifiedById { get; set; }
+}

--- a/Entities/Order.cs
+++ b/Entities/Order.cs
@@ -1,0 +1,46 @@
+﻿namespace AdminHubApi.Entities;
+
+public class Order
+{
+    public Guid Id { get; set; }
+
+    // Optional link to registered user
+    public string CustomerId { get; set; }
+    public ApplicationUser Customer { get; set; }
+
+    // Order-specific customer information
+    public string CustomerName { get; set; }
+    public string CustomerEmail { get; set; }
+    public string CustomerPhone { get; set; }
+
+    public DateTime OrderDate { get; set; }
+
+    public decimal TotalAmount { get; set; }
+
+    public OrderStatus Status { get; set; }
+
+    public string ShippingAddress { get; set; }
+
+    public string BillingAddress { get; set; }
+
+    public string PaymentMethod { get; set; }
+
+    public DateTime Created { get; set; }
+    public string CreatedById { get; set; }
+    public ApplicationUser CreatedBy { get; set; }
+
+    public DateTime Modified { get; set; }
+    public string ModifiedById { get; set; }
+    public ApplicationUser ModifiedBy { get; set; }
+
+    public ICollection<OrderItem> OrderItems { get; set; } = new List<OrderItem>();
+}
+
+public enum OrderStatus
+{
+    Pending = 0,
+    Processing = 1,
+    Shipped = 2,
+    Delivered = 3,
+    Cancelled = 4
+}

--- a/Entities/OrderItem.cs
+++ b/Entities/OrderItem.cs
@@ -1,0 +1,30 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AdminHubApi.Entities;
+
+public class OrderItem
+{
+    public Guid Id { get; set; }
+    
+    public Guid OrderId { get; set; }
+    public Order Order { get; set; }
+    
+    public Guid ProductId { get; set; }
+    public Product Product { get; set; }
+    
+    public int Quantity { get; set; }
+    
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal UnitPrice { get; set; }
+    
+    [Column(TypeName = "decimal(18,2)")]
+    public decimal Subtotal { get; set; }
+    
+    public DateTime Created { get; set; }
+    public string CreatedById { get; set; }
+    public ApplicationUser CreatedBy { get; set; }
+    
+    public DateTime Modified { get; set; }
+    public string ModifiedById { get; set; }
+    public ApplicationUser ModifiedBy { get; set; }
+}

--- a/Interfaces/IOrderRepository.cs
+++ b/Interfaces/IOrderRepository.cs
@@ -1,0 +1,23 @@
+﻿using AdminHubApi.Entities;
+
+namespace AdminHubApi.Interfaces;
+
+public interface IOrderRepository
+{
+    Task<IEnumerable<Order>> GetAllAsync();
+    Task<Order?> GetByIdAsync(Guid id);
+    Task<IEnumerable<Order>> GetByCustomerIdAsync(string customerId);
+    Task<IEnumerable<Order>> GetByStatusAsync(OrderStatus status);
+    Task<Order> CreateAsync(Order order);
+    Task UpdateAsync(Order order);
+    Task DeleteAsync(Guid id);
+}
+
+public interface IOrderItemRepository
+{
+    Task<IEnumerable<OrderItem>> GetByOrderIdAsync(Guid orderId);
+    Task<OrderItem?> GetByIdAsync(Guid id);
+    Task<OrderItem> CreateAsync(OrderItem orderItem);
+    Task UpdateAsync(OrderItem orderItem);
+    Task DeleteAsync(Guid id);
+}

--- a/Interfaces/IOrderService.cs
+++ b/Interfaces/IOrderService.cs
@@ -1,0 +1,17 @@
+﻿using AdminHubApi.Dtos.ApiResponse;
+using AdminHubApi.Dtos.Orders;
+using AdminHubApi.Entities;
+
+namespace AdminHubApi.Interfaces;
+
+public interface IOrderService
+{
+    Task<ApiResponse<IEnumerable<OrderResponseDto>>> GetAllAsync();
+    Task<ApiResponse<OrderResponseDto>> GetByIdAsync(Guid id);
+    Task<ApiResponse<IEnumerable<OrderResponseDto>>> GetByCustomerIdAsync(string customerId);
+    Task<ApiResponse<IEnumerable<OrderResponseDto>>> GetByStatusAsync(OrderStatus status);
+    Task<ApiResponse<OrderResponseDto>> CreateAsync(Order order, List<OrderItem> orderItems);
+    Task<ApiResponse<OrderResponseDto>> UpdateAsync(Order order);
+    Task<ApiResponse<bool>> DeleteAsync(Guid id);
+    Task<ApiResponse<CustomerInfo>> GetCustomerInfoAsync(string customerId);
+}

--- a/Migrations/20250508190532_AddOrderAndOrderItemsTables.Designer.cs
+++ b/Migrations/20250508190532_AddOrderAndOrderItemsTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AdminHubApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AdminHubApi.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250508190532_AddOrderAndOrderItemsTables")]
+    partial class AddOrderAndOrderItemsTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -128,16 +131,7 @@ namespace AdminHubApi.Migrations
                     b.Property<string>("CreatedById")
                         .HasColumnType("text");
 
-                    b.Property<string>("CustomerEmail")
-                        .HasColumnType("text");
-
                     b.Property<string>("CustomerId")
-                        .HasColumnType("text");
-
-                    b.Property<string>("CustomerName")
-                        .HasColumnType("text");
-
-                    b.Property<string>("CustomerPhone")
                         .HasColumnType("text");
 
                     b.Property<DateTime>("Modified")

--- a/Migrations/20250508190532_AddOrderAndOrderItemsTables.cs
+++ b/Migrations/20250508190532_AddOrderAndOrderItemsTables.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AdminHubApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderAndOrderItemsTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CustomerId = table.Column<string>(type: "text", nullable: true),
+                    OrderDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    TotalAmount = table.Column<decimal>(type: "numeric", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    ShippingAddress = table.Column<string>(type: "text", nullable: true),
+                    BillingAddress = table.Column<string>(type: "text", nullable: true),
+                    PaymentMethod = table.Column<string>(type: "text", nullable: true),
+                    Created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedById = table.Column<string>(type: "text", nullable: true),
+                    Modified = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedById = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Orders_AspNetUsers_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Orders_AspNetUsers_CustomerId",
+                        column: x => x.CustomerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Orders_AspNetUsers_ModifiedById",
+                        column: x => x.ModifiedById,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OrderItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Quantity = table.Column<int>(type: "integer", nullable: false),
+                    UnitPrice = table.Column<decimal>(type: "numeric(18,2)", nullable: false),
+                    Subtotal = table.Column<decimal>(type: "numeric(18,2)", nullable: false),
+                    Created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedById = table.Column<string>(type: "text", nullable: true),
+                    Modified = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedById = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrderItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrderItems_AspNetUsers_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_OrderItems_AspNetUsers_ModifiedById",
+                        column: x => x.ModifiedById,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_OrderItems_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrderItems_Products_ProductId",
+                        column: x => x.ProductId,
+                        principalTable: "Products",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderItems_CreatedById",
+                table: "OrderItems",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderItems_ModifiedById",
+                table: "OrderItems",
+                column: "ModifiedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderItems_OrderId",
+                table: "OrderItems",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderItems_ProductId",
+                table: "OrderItems",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_CreatedById",
+                table: "Orders",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_CustomerId",
+                table: "Orders",
+                column: "CustomerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Orders_ModifiedById",
+                table: "Orders",
+                column: "ModifiedById");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrderItems");
+
+            migrationBuilder.DropTable(
+                name: "Orders");
+        }
+    }
+}

--- a/Migrations/20250508193256_UpdatedCustomerColumnsInOrdersTable.Designer.cs
+++ b/Migrations/20250508193256_UpdatedCustomerColumnsInOrdersTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AdminHubApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AdminHubApi.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250508193256_UpdatedCustomerColumnsInOrdersTable")]
+    partial class UpdatedCustomerColumnsInOrdersTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250508193256_UpdatedCustomerColumnsInOrdersTable.cs
+++ b/Migrations/20250508193256_UpdatedCustomerColumnsInOrdersTable.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AdminHubApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdatedCustomerColumnsInOrdersTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerEmail",
+                table: "Orders",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerName",
+                table: "Orders",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerPhone",
+                table: "Orders",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CustomerEmail",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "CustomerName",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "CustomerPhone",
+                table: "Orders");
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -144,7 +144,7 @@ builder.Services.AddScoped<IOrderItemRepository, OrderItemRepository>();
 builder.Services.AddHostedService<TokenCleanupService>();
 
 // Custom Authorization Handler
-// builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, CustomAuthorizationMiddlewareResultHandler>();
+builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, CustomAuthorizationMiddlewareResultHandler>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
@@ -187,14 +187,15 @@ using (var scope = app.Services.CreateScope())
             await ManagerUserSeeder.SeedManagerUserAsync(app.Services);
         }
         
-        // Always update roles to ensure new permissions are added
-        logger.LogInformation("Seeding roles...");
-        await RoleSeeder.SeedRolesAsync(app.Services);
-        
         // Always update permissions to ensure new permissions are added
         logger.LogInformation("Updating role permissions...");
         await PermissionUpdateSeeder.UpdateRolePermissionsAsync(app.Services);
         logger.LogInformation("Role permissions updated successfully");
+        
+        logger.LogInformation("Updating user permissions...");
+        await UserPermissionUpdateSeeder.UpdateUserPermissionsAsync(app.Services);
+        logger.LogInformation("User permissions updated successfully");
+
 
         logger.LogInformation("Database seeding completed successfully");
     }

--- a/Program.cs
+++ b/Program.cs
@@ -130,18 +130,21 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IProjectService, ProjectService>();
 builder.Services.AddScoped<IProductService, ProductService>();
 builder.Services.AddScoped<IProductCategoryService, ProductCategoryService>();
+builder.Services.AddScoped<IOrderService, OrderService>();
 
 // Repository
 builder.Services.AddScoped<IProjectRepository, ProjectRepository>();
 builder.Services.AddScoped<ITokenBlacklistRepository, TokenBlacklistRepository>();
 builder.Services.AddScoped<IProductRepository, ProductRepository>();
 builder.Services.AddScoped<IProductCategoryRepository, ProductCategoryRepository>();
+builder.Services.AddScoped<IOrderRepository, OrderRepository>();
+builder.Services.AddScoped<IOrderItemRepository, OrderItemRepository>();
 
 // Register token cleanup background service
 builder.Services.AddHostedService<TokenCleanupService>();
 
 // Custom Authorization Handler
-builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, CustomAuthorizationMiddlewareResultHandler>();
+// builder.Services.AddSingleton<IAuthorizationMiddlewareResultHandler, CustomAuthorizationMiddlewareResultHandler>();
 
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
@@ -159,7 +162,7 @@ using (var scope = app.Services.CreateScope())
     try
     {
         logger.LogInformation("Applying database migrations...");
-        db.Database.Migrate(); // This applies pending migrations automatically
+        db.Database.Migrate(); // This applies to pending migrations automatically
         logger.LogInformation("Database migrations applied successfully");
 
         // Check if we need to seed users and roles
@@ -183,6 +186,10 @@ using (var scope = app.Services.CreateScope())
             await NormalUserSeeder.SeedNormalUserAsync(app.Services);
             await ManagerUserSeeder.SeedManagerUserAsync(app.Services);
         }
+        
+        // Always update roles to ensure new permissions are added
+        logger.LogInformation("Seeding roles...");
+        await RoleSeeder.SeedRolesAsync(app.Services);
         
         // Always update permissions to ensure new permissions are added
         logger.LogInformation("Updating role permissions...");

--- a/Repositories/OrderRepository.cs
+++ b/Repositories/OrderRepository.cs
@@ -1,0 +1,137 @@
+﻿using AdminHubApi.Data;
+using AdminHubApi.Entities;
+using AdminHubApi.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace AdminHubApi.Repositories;
+
+public class OrderRepository : IOrderRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public OrderRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IEnumerable<Order>> GetAllAsync()
+    {
+        return await _context.Orders
+            .Include(o => o.Customer)
+            .Include(o => o.CreatedBy)
+            .Include(o => o.ModifiedBy)
+            .Include(o => o.OrderItems)
+                .ThenInclude(oi => oi.Product)
+            .ToListAsync();
+    }
+
+    public async Task<Order?> GetByIdAsync(Guid id)
+    {
+        return await _context.Orders
+            .Include(o => o.Customer)
+            .Include(o => o.CreatedBy)
+            .Include(o => o.ModifiedBy)
+            .Include(o => o.OrderItems)
+                .ThenInclude(oi => oi.Product)
+            .FirstOrDefaultAsync(o => o.Id == id);
+    }
+
+    public async Task<IEnumerable<Order>> GetByCustomerIdAsync(string customerId)
+    {
+        return await _context.Orders
+            .Include(o => o.Customer)
+            .Include(o => o.CreatedBy)
+            .Include(o => o.ModifiedBy)
+            .Include(o => o.OrderItems)
+                .ThenInclude(oi => oi.Product)
+            .Where(o => o.CustomerId == customerId)
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<Order>> GetByStatusAsync(OrderStatus status)
+    {
+        return await _context.Orders
+            .Include(o => o.Customer)
+            .Include(o => o.CreatedBy)
+            .Include(o => o.ModifiedBy)
+            .Include(o => o.OrderItems)
+                .ThenInclude(oi => oi.Product)
+            .Where(o => o.Status == status)
+            .ToListAsync();
+    }
+
+    public async Task<Order> CreateAsync(Order order)
+    {
+        await _context.Orders.AddAsync(order);
+        await _context.SaveChangesAsync();
+        return order;
+    }
+
+    public async Task UpdateAsync(Order order)
+    {
+        _context.Orders.Update(order);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(Guid id)
+    {
+        var order = await _context.Orders.FindAsync(id);
+        if (order != null)
+        {
+            _context.Orders.Remove(order);
+            await _context.SaveChangesAsync();
+        }
+    }
+}
+
+public class OrderItemRepository : IOrderItemRepository
+{
+    private readonly ApplicationDbContext _context;
+
+    public OrderItemRepository(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IEnumerable<OrderItem>> GetByOrderIdAsync(Guid orderId)
+    {
+        return await _context.OrderItems
+            .Include(oi => oi.Product)
+            .Include(oi => oi.CreatedBy)
+            .Include(oi => oi.ModifiedBy)
+            .Where(oi => oi.OrderId == orderId)
+            .ToListAsync();
+    }
+
+    public async Task<OrderItem?> GetByIdAsync(Guid id)
+    {
+        return await _context.OrderItems
+            .Include(oi => oi.Product)
+            .Include(oi => oi.CreatedBy)
+            .Include(oi => oi.ModifiedBy)
+            .FirstOrDefaultAsync(oi => oi.Id == id);
+    }
+
+    public async Task<OrderItem> CreateAsync(OrderItem orderItem)
+    {
+        await _context.OrderItems.AddAsync(orderItem);
+        await _context.SaveChangesAsync();
+        return orderItem;
+    }
+
+    public async Task UpdateAsync(OrderItem orderItem)
+    {
+        _context.OrderItems.Update(orderItem);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(Guid id)
+    {
+        var orderItem = await _context.OrderItems.FindAsync(id);
+        if (orderItem != null)
+        {
+            _context.OrderItems.Remove(orderItem);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/Services/OrderService.cs
+++ b/Services/OrderService.cs
@@ -1,0 +1,352 @@
+﻿using AdminHubApi.Dtos.ApiResponse;
+using AdminHubApi.Dtos.OrderItem;
+using AdminHubApi.Dtos.Orders;
+using AdminHubApi.Entities;
+using AdminHubApi.Interfaces;
+using Microsoft.AspNetCore.Identity;
+
+namespace AdminHubApi.Services;
+
+public class OrderService : IOrderService
+{
+    private readonly IOrderRepository _orderRepository;
+    private readonly IOrderItemRepository _orderItemRepository;
+    private readonly IProductRepository _productRepository;
+    private readonly ILogger<OrderService> _logger;
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public OrderService(
+        IOrderRepository orderRepository,
+        IOrderItemRepository orderItemRepository,
+        IProductRepository productRepository,
+        UserManager<ApplicationUser> userManager,
+        ILogger<OrderService> logger
+    )
+    {
+        _orderRepository = orderRepository;
+        _orderItemRepository = orderItemRepository;
+        _productRepository = productRepository;
+        _logger = logger;
+        _userManager = userManager;
+    }
+
+    public async Task<ApiResponse<IEnumerable<OrderResponseDto>>> GetAllAsync()
+    {
+        try
+        {
+            var orders = await _orderRepository.GetAllAsync();
+            var orderResponseDtos = orders.Select(MapToOrderResponseDto);
+
+            return new ApiResponse<IEnumerable<OrderResponseDto>>
+            {
+                Succeeded = true,
+                Data = orderResponseDtos
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting all orders");
+
+            return new ApiResponse<IEnumerable<OrderResponseDto>>
+            {
+                Succeeded = false,
+                Message = "Error getting all orders",
+                Errors = new List<string> { ex.Message }
+            };
+        }
+    }
+
+    public async Task<ApiResponse<OrderResponseDto>> GetByIdAsync(Guid id)
+    {
+        try
+        {
+            var order = await _orderRepository.GetByIdAsync(id);
+
+            if (order == null)
+            {
+                return new ApiResponse<OrderResponseDto>
+                {
+                    Succeeded = false,
+                    Message = $"Order with ID {id} not found",
+                    Errors = new List<string> { $"Order with ID {id} not found" }
+                };
+            }
+
+            return new ApiResponse<OrderResponseDto>
+            {
+                Succeeded = true,
+                Data = MapToOrderResponseDto(order)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting order by id {Id}", id);
+
+            return new ApiResponse<OrderResponseDto>
+            {
+                Succeeded = false,
+                Message = $"Error getting order by id {id}",
+                Errors = new List<string> { ex.Message }
+            };
+        }
+    }
+
+    public async Task<ApiResponse<IEnumerable<OrderResponseDto>>> GetByCustomerIdAsync(string customerId)
+    {
+        try
+        {
+            var orders = await _orderRepository.GetByCustomerIdAsync(customerId);
+            var orderResponseDtos = orders.Select(MapToOrderResponseDto);
+
+            return new ApiResponse<IEnumerable<OrderResponseDto>>
+            {
+                Succeeded = true,
+                Data = orderResponseDtos
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting orders for customer {CustomerId}", customerId);
+
+            return new ApiResponse<IEnumerable<OrderResponseDto>>
+            {
+                Succeeded = false,
+                Message = $"Error getting orders for customer {customerId}",
+                Errors = new List<string> { ex.Message }
+            };
+        }
+    }
+
+    public async Task<ApiResponse<IEnumerable<OrderResponseDto>>> GetByStatusAsync(OrderStatus status)
+    {
+        try
+        {
+            var orders = await _orderRepository.GetByStatusAsync(status);
+            var orderResponseDtos = orders.Select(MapToOrderResponseDto);
+
+            return new ApiResponse<IEnumerable<OrderResponseDto>>
+            {
+                Succeeded = true,
+                Data = orderResponseDtos
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting orders by status {Status}", status);
+
+            return new ApiResponse<IEnumerable<OrderResponseDto>>
+            {
+                Succeeded = false,
+                Message = $"Error getting orders by status {status}",
+                Errors = new List<string> { ex.Message }
+            };
+        }
+    }
+
+    public async Task<ApiResponse<OrderResponseDto>> CreateAsync(Order order, List<OrderItem> orderItems)
+    {
+        try
+        {
+            decimal totalAmount = 0;
+
+            foreach (var item in orderItems)
+            {
+                var product = await _productRepository.GetByIdAsync(item.ProductId);
+
+                if (product == null)
+                {
+                    return new ApiResponse<OrderResponseDto>
+                    {
+                        Succeeded = false,
+                        Message = $"Product with ID {item.ProductId} not found",
+                        Errors = new List<string> { $"Product with ID {item.ProductId} not found" }
+                    };
+                }
+
+                if (product.QuantityInStock < item.Quantity)
+                {
+                    return new ApiResponse<OrderResponseDto>
+                    {
+                        Succeeded = false,
+                        Message = $"Not enough stock for product {product.Title}",
+                        Errors = new List<string> { $"Not enough stock for product {product.Title}" }
+                    };
+                }
+
+                item.UnitPrice = product.Price;
+                item.Subtotal = item.UnitPrice * item.Quantity;
+                item.Created = DateTime.UtcNow;
+                item.Modified = DateTime.UtcNow;
+                item.CreatedById = order.CreatedById;
+                item.ModifiedById = order.ModifiedById;
+
+                totalAmount += item.Subtotal;
+
+                // Update product stock
+                product.QuantityInStock -= item.Quantity;
+                await _productRepository.UpdateAsync(product);
+            }
+
+            order.TotalAmount = totalAmount;
+            order.OrderDate = DateTime.UtcNow;
+
+            var createdOrder = await _orderRepository.CreateAsync(order);
+
+            foreach (var item in orderItems)
+            {
+                item.OrderId = createdOrder.Id;
+                await _orderItemRepository.CreateAsync(item);
+            }
+
+            // Retrieve the complete order with items
+            var completeOrder = await _orderRepository.GetByIdAsync(createdOrder.Id);
+
+            return new ApiResponse<OrderResponseDto>
+            {
+                Succeeded = true,
+                Data = MapToOrderResponseDto(completeOrder!)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating order");
+
+            return new ApiResponse<OrderResponseDto>
+            {
+                Succeeded = false,
+                Message = "Error creating order",
+                Errors = new List<string> { ex.Message }
+            };
+        }
+    }
+
+    public async Task<ApiResponse<OrderResponseDto>> UpdateAsync(Order order)
+    {
+        try
+        {
+            await _orderRepository.UpdateAsync(order);
+
+            var updatedOrder = await _orderRepository.GetByIdAsync(order.Id);
+
+            return new ApiResponse<OrderResponseDto>
+            {
+                Succeeded = true,
+                Data = MapToOrderResponseDto(updatedOrder!)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating order {Id}", order.Id);
+
+            return new ApiResponse<OrderResponseDto>
+            {
+                Succeeded = false,
+                Message = $"Error updating order {order.Id}",
+                Errors = new List<string> { ex.Message }
+            };
+        }
+    }
+
+    public async Task<ApiResponse<bool>> DeleteAsync(Guid id)
+    {
+        try
+        {
+            await _orderRepository.DeleteAsync(id);
+
+            return new ApiResponse<bool>
+            {
+                Succeeded = true,
+                Data = true
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting order {Id}", id);
+
+            return new ApiResponse<bool>
+            {
+                Succeeded = false,
+                Message = $"Error deleting order {id}",
+                Errors = new List<string> { ex.Message }
+            };
+        }
+    }
+
+    public async Task<ApiResponse<CustomerInfo>> GetCustomerInfoAsync(string customerId)
+    {
+        try
+        {
+            var user = await _userManager.FindByIdAsync(customerId);
+
+            if (user == null)
+            {
+                return new ApiResponse<CustomerInfo>
+                {
+                    Succeeded = false,
+                    Message = $"User with ID {customerId} not found",
+                    Errors = new List<string> { $"User with ID {customerId} not found" }
+                };
+            }
+
+            return new ApiResponse<CustomerInfo>
+            {
+                Succeeded = true,
+                Data = new CustomerInfo
+                {
+                    Name = user.UserName,
+                    Email = user.Email,
+                    Phone = user.PhoneNumber
+                }
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting customer info for user {CustomerId}", customerId);
+
+            return new ApiResponse<CustomerInfo>
+            {
+                Succeeded = false,
+                Message = $"Error getting customer info for user {customerId}",
+                Errors = new List<string> { ex.Message }
+            };
+        }
+    }
+
+    private static OrderResponseDto MapToOrderResponseDto(Order order)
+    {
+        return new OrderResponseDto
+        {
+            Id = order.Id,
+            // Include both registered user info and order-specific customer info
+            CustomerId = order.CustomerId,
+            CustomerName = order.CustomerName,
+            CustomerEmail = order.CustomerEmail,
+            CustomerPhone = order.CustomerPhone,
+
+            OrderDate = order.OrderDate,
+            TotalAmount = order.TotalAmount,
+            Status = order.Status,
+            ShippingAddress = order.ShippingAddress,
+            BillingAddress = order.BillingAddress,
+            PaymentMethod = order.PaymentMethod,
+            OrderItems = order.OrderItems.Select(oi => new OrderItemResponseDto
+            {
+                Id = oi.Id,
+                OrderId = oi.OrderId,
+                ProductId = oi.ProductId,
+                ProductName = oi.Product?.Title,
+                Quantity = oi.Quantity,
+                UnitPrice = oi.UnitPrice,
+                Subtotal = oi.Subtotal,
+                Created = oi.Created,
+                Modified = oi.Modified
+            }).ToList(),
+            Created = order.Created,
+            CreatedById = order.CreatedById,
+            CreatedByName = order.CreatedBy?.UserName,
+            Modified = order.Modified,
+            ModifiedById = order.ModifiedById,
+            ModifiedByName = order.ModifiedBy?.UserName
+        };
+    }
+}


### PR DESCRIPTION
```
**Description**
This pull request includes:
- New permissions for orders: View, Create, Edit, and Delete.
- Updated seeders to include the above permissions and revised default user email and claims settings.
- Added `Orders` and `OrderItems` database tables, along with relationships to existing `Products` and `AspNetUsers` tables.
- Inclusion of customer details (`CustomerEmail`, `CustomerName`, `CustomerPhone`) as columns in the `Orders` table for better order management.

**Type of Change**
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Enhancement
```